### PR TITLE
Changing micropython-logging to -ulogging

### DIFF
--- a/wesp32_light_server/install-modules.py
+++ b/wesp32_light_server/install-modules.py
@@ -21,6 +21,6 @@ while lan.ifconfig()[0] == '0.0.0.0':
 # Install picoweb
 print("Network connection established, installing picoweb...")
 upip.install('picoweb')
-# Install micropython-logging
-upip.install('micropython-logging')
+# Install micropython-ulogging
+upip.install('micropython-ulogging')
 print("Installation finished.")


### PR DESCRIPTION
A recent-ish change in picoweb (https://github.com/pfalcon/picoweb/commit/98933cc0ff25610e478f6cfb91f57c340a727118) will require you to install micropython-**u**logging instead of micropython-logging for the light server demo to work.