### PR TITLE
Use CRLFs in HTTP Header

### DIFF
--- a/wesp32_light_server_socket/main.py
+++ b/wesp32_light_server_socket/main.py
@@ -57,9 +57,9 @@ while True:
     print('LED OFF')
     led.value(0)
   response = web_page()
-  conn.send('HTTP/1.1 200 OK\n')
-  conn.send('Content-Type: text/html\n')
-  conn.send('Connection: close\n\n')
+  conn.send('HTTP/1.1 200 OK\r\n')
+  conn.send('Content-Type: text/html\r\n')
+  conn.send('Connection: close\r\n\r\n')
   conn.sendall(response)
   conn.close()
 


### PR DESCRIPTION
So, I have been playing with the RandomNerdTutorials demo, an ESP8266-based board, and more or less this script. But I've been trying to ingest the output of the HTTP request into a .NET application. Turns out, this example uses invalid HTTP, and I spent a while trying to figure out what was going on. Turns out that while most web browsers seem to be not all that picky about it, you have to use a CRLF to terminate each HTTP header, and then two CRLFs to terminate the header block. LFs are not adequate to meet the standard, and .NET is picky enough to throw an HTTP Protocol Violation when it receives this in an HttpWebResponse.

Demo code should ideally be compliant with standards, and this is a quick fix. (I noticed RNT as well.)